### PR TITLE
Improve error handling and add tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,17 @@ impl ThreadPool {
         }
     }
 
+    /// Sends the given function f to a thread in the thread pool to be executed
+    pub fn execute<F>(&self, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let job = Box::new(f);
+
+        self.sender.as_ref().unwrap().send(job).unwrap();
+    }
+}
+
 impl Drop for ThreadPool {
     fn drop(&mut self) {
         drop(self.sender.take());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,28 +55,6 @@ impl ThreadPool {
         }
     }
 
-    /// Creates a new ThreadPool
-    ///
-    /// The capacity is the number of threads in the pool.
-    ///
-    /// # Errors
-    ///
-    /// `PoolCreationError` if capacity is zero.
-    pub fn build(capacity: usize) -> Result<ThreadPool, PoolCreationError> {
-        Self::new(capacity)
-    }
-
-    /// Sends the given function f to a thread in the thread pool to be executed
-    pub fn execute<F>(&self, f: F)
-    where
-        F: FnOnce() + Send + 'static,
-    {
-        let job = Box::new(f);
-
-        self.sender.as_ref().unwrap().send(job).unwrap();
-    }
-}
-
 impl Drop for ThreadPool {
     fn drop(&mut self) {
         drop(self.sender.take());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,3 +105,20 @@ impl Worker {
         Worker { id, thread }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_new_thread_pool() {
+        let thread_pool = ThreadPool::new(5);
+        assert!(thread_pool.is_ok());
+    }
+
+    #[test]
+    fn create_new_thread_pool_error() {
+        let thread_pool = ThreadPool::new(0);
+        assert!(thread_pool.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,11 @@ fn main() {
     for stream in listener.incoming().take(10) {
         let stream = stream.unwrap();
 
-        thread_pool.execute(|| handle_connection(stream));
+        if let Ok(tp) = &thread_pool {
+            tp.execute(|| handle_connection(stream));
+        } else {
+            break;
+        }
     }
 
     println!("Shutting down.");


### PR DESCRIPTION
This PR adds the following

- Improve error handling when creating a new thread pool.
- Remove redundant `build` method.
- Add unit tests to test creating a new thread pool